### PR TITLE
Allow to use custom HTTP header name instead of X-Forwarded-For

### DIFF
--- a/install/radiance.conf
+++ b/install/radiance.conf
@@ -10,6 +10,9 @@ max_read_buffer     = 4096
 connection_timeout  = 10
 # Keepalive is mostly useful if the tracker runs behind reverse proxies
 keepalive_timeout   = 0
+# Override the client IP with the HTTP header provided by a proxy or load balancer (nginx, etc.).
+# Disabled by default
+real_ip_header      = X-Forwarded-For
 
 announce_interval   = 1800
 max_request_size    = 4096

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -81,6 +81,7 @@ void settings::init() {
 	add("max_read_buffer", 4096u);
 	add("connection_timeout", 10u);
 	add("keepalive_timeout", 0u);
+	add("real_ip_header", "");
 
 	// Tracker requests
 	add("announce_interval", 1800u);

--- a/src/worker.h
+++ b/src/worker.h
@@ -43,6 +43,7 @@ class worker {
 		unsigned int peers_timeout;
 		unsigned int numwant_limit;
 		bool keepalive_enabled, anonymous;
+		std::string real_ip_header;
 		std::string site_password;
 		std::string report_password;
 		std::string anonymous_password;


### PR DESCRIPTION
Previously the IP address was taken from the X-Forwarded-For header, regardless of whether Radiance works through a proxy or independently.

Now in config you can set some other header.

Now this header is not set by default, because when configuring Radiance to work through a proxy, in any case, anyone will need to additionally configure nginx to write the IP address to some additional header ([nginx uses X-Real-IP by default](https://nginx.org/en/docs/http/ngx_http_realip_module.html)).